### PR TITLE
001 Fix

### DIFF
--- a/framework/db/schema/CDbCommandBuilder.php
+++ b/framework/db/schema/CDbCommandBuilder.php
@@ -226,7 +226,7 @@ class CDbCommandBuilder extends CComponent
 				else
 				{
 					$placeholders[]=self::PARAM_PREFIX.$i;
-          $values[self::PARAM_PREFIX.$i]=($column->allowNull && $value === '') ? null : $column->typecast($value);
+          $values[self::PARAM_PREFIX.$i]=$column->typecast($value);
 					$i++;
 				}
 			}
@@ -386,7 +386,7 @@ class CDbCommandBuilder extends CComponent
 				else
 				{
 					$fields[]=$column->rawName.'='.self::PARAM_PREFIX.$i;
-          $values[self::PARAM_PREFIX.$i]=($column->allowNull && $value === '') ? null : $column->typecast($value);
+          $values[self::PARAM_PREFIX.$i]=$column->typecast($value);
 					$i++;
 				}
 			}


### PR DESCRIPTION
001
Description: Os campos Allow Null do MySQL estavam salvando um valor vazio e n„o NULL, isso gera erros de cast (date, integer)
File: yii-path\framework\db\schema\CDbCommandBuilder.php
Method: createInsertCommand, createUpdateCommand
Line: 229, 389
Original content:
    $values[self::PARAM_PREFIX.$i]=$column->typecast($value);
Replace with:
    $values[self::PARAM_PREFIX.$i]=($column->allowNull && $value === '') ? null : $column->typecast($value);