### PR TITLE
Revert change

### DIFF
--- a/framework/db/CDbDataReader.php
+++ b/framework/db/CDbDataReader.php
@@ -106,7 +106,7 @@ class CDbDataReader extends CComponent implements Iterator, Countable
 	 * @param array $fields Elements of this array are passed to the constructor
 	 * @return mixed|false the populated object, false if no more row of data available
 	 */
-  public function readObject($className='stdClass',$fields=array())
+  public function readObject($className,$fields)
 	{
 		return $this->_statement->fetchObject($className,$fields);
 	}
@@ -116,9 +116,9 @@ class CDbDataReader extends CComponent implements Iterator, Countable
 	 * @return array the result set (each array element represents a row of data).
 	 * An empty array will be returned if the result contains no row.
 	 */
-  public function readAll($fetchStyle=PDO::FETCH_BOTH)
+  public function readAll()
   {
-    return $this->_statement->fetchAll($fetchStyle);
+    return $this->_statement->fetchAll();
   }
 
 	/**


### PR DESCRIPTION
002
Description: fazer o método se comportar conforme os fetch* nativo do PDO
File: yii-path\framework\db\CDbDataReader.php
Method: readObject
Line 109
    Original
        public function readObject($className,$fields)
    Replace
        public function readObject($className='stdClass',$fields=array())

Line 119
    Original
        public function readAll()
        {
            return $this->_statement->fetchAll();
        }
    Replace
        public function readAll($fetchStyle=PDO::FETCH_BOTH)
        {
            return $this->_statement->fetchAll($fetchStyle);
        }