### PR TITLE
004 Fix

### DIFF
--- a/framework/gii/generators/model/ModelCode.php
+++ b/framework/gii/generators/model/ModelCode.php
@@ -407,8 +407,8 @@ class ModelCode extends CCodeModel
 			$relationName=$fkName;
 		$relationName[0]=strtolower($relationName[0]);
 
-//		if($multiple)
-//			$relationName=$this->pluralize($relationName);
+		if($multiple)
+			$relationName=$this->pluralize($relationName);
 
 		$names=preg_split('/_+/',$relationName,-1,PREG_SPLIT_NO_EMPTY);
 		if(empty($names)) return $relationName;  // unlikely


### PR DESCRIPTION
004
Description: não criar nomes pluralizados para relacionamentos HAS_MANY
File: yii-path\framework\gii\generators\model\ModelCode.php
Method: generateRelationName
Line: 410 e 411
    Replace
        //if($multiple)
        //    $relationName=$this->pluralize($relationName);