### PR TITLE
007 Fix

### DIFF
--- a/framework/db/ar/CActiveFinder.php
+++ b/framework/db/ar/CActiveFinder.php
@@ -852,8 +852,7 @@ class CJoinElement
 				if(isset($aliases[$alias]))
 					$attributes[$aliases[$alias]]=$value;
 			}
-      $scenario = isset($this->relation->scenario) ? $this->relation->scenario : 'update';
-      $record=$this->model->populateRecord($attributes,false,$scenario);
+      $record=$this->model->populateRecord($attributes,false);
 			foreach($this->children as $child)
 			{
 				if(!empty($child->relation->select))

--- a/framework/db/ar/CActiveRecord.php
+++ b/framework/db/ar/CActiveRecord.php
@@ -1853,12 +1853,12 @@ abstract class CActiveRecord extends CModel
 	 * @return static|null the newly created active record. The class of the object is the same as the model class.
 	 * Null is returned if the input data is false.
 	 */
-  public function populateRecord($attributes,$callAfterFind=true,$scenario='update')
+  public function populateRecord($attributes,$callAfterFind=true)
 	{
 		if($attributes!==false)
 		{
 			$record=$this->instantiate($attributes);
-      $record->setScenario($scenario);
+      $record->setScenario('update');
 			$record->init();
 			$md=$record->getMetaData();
 			foreach($attributes as $name=>$value)
@@ -2182,8 +2182,6 @@ class CActiveRelation extends CBaseActiveRelation
 	 */
 	public $through;
 
-  public $scenario;
-
 	/**
 	 * Merges this relation with a criteria specified dynamically.
 	 * @param array $criteria the dynamically specified criteria
@@ -2226,9 +2224,6 @@ class CActiveRelation extends CBaseActiveRelation
 
 		if(isset($criteria['together']))
 			$this->together=$criteria['together'];
-
-    if(isset($criteria['scenario']))
-      $this->scenario=$criteria['scenario'];
 	}
 }
 


### PR DESCRIPTION
007
Implementação da utilização de cenários nas relations
File: yii-path\framework\db\ar\CActiveFinder.php
Method: CActiveRecord::populateRecord
Line: 855
    Original
        $record=$this->model->populateRecord($attributes,false);
    Replace
        $scenario = isset($this->relation->scenario) ? $this->relation->scenario : 'update';
        $record=$this->model->populateRecord($attributes,false,$scenario);

File: yii-path\framework\db\ar\CActiveRecord.php
Method: populateRecord
Line: 1856
    Original
        public function populateRecord($attributes,$callAfterFind=true)
    Replace
        public function populateRecord($attributes,$callAfterFind=true,$scenario='update')
Line: 1861
    Original
        $record->setScenario('update');
    Replace
        $record->setScenario($scenario);
Class: CActiveRelation
Line: 2184
    Add (ao final das declarações das propriedades)
        public $scenario;
Method: CActiveRelation::mergeWith
Line: 2229
    Add (no final do método)
        if(isset($criteria['scenario']))
            $this->scenario=$criteria['scenario'];